### PR TITLE
New rule for text color inside span on main page

### DIFF
--- a/MyAnimeListDeepDark.user.css
+++ b/MyAnimeListDeepDark.user.css
@@ -2,7 +2,7 @@
 @name MyAnimeList DeepDark
 @namespace gitlab.com/RaitaroH/MyAnimeList-DeepDark
 @homepageURL https://gitlab.com/RaitaroH/MyAnimeList-DeepDark
-@version 1.6.51
+@version 1.6.52
 @updateURL https://gitlab.com/RaitaroH/MyAnimeList-DeepDark/raw/master/MyAnimeListDeepDark.user.css
 @description  Satisfy thy craving for anime and organization. May the dark be kinder on thine eyes. (MyAnimeList Dark Theme)
 @author RaitaroH

--- a/MyAnimeListDeepDark.user.css
+++ b/MyAnimeListDeepDark.user.css
@@ -635,10 +635,10 @@
 	/*Button*/
 	.page-common #header-menu .header-menu-login .btn-mal-service, .page-common #header-menu .header-menu-login .btn-signup, .page-common #header-menu .header-menu-login .btn-login, .page-common .header-menu-login .btn-signup
 	{
-	border-color: var(--main-color) !important;
-	background-color: var(--main-color) !important;
-	color: var(--main-text) !important;
-	opacity: .9;
+		border-color: var(--main-color) !important;
+		background-color: var(--main-color) !important;
+		color: var(--main-text) !important;
+		opacity: .9;
 	}
 	.page-common #header-menu .header-menu-login .btn-mal-service:hover, .page-common #header-menu .header-menu-login .btn-signup:hover, .page-common #header-menu .header-menu-login .btn-login:hover, .page-common .header-menu-login .btn-signup:hover
 	{
@@ -1254,7 +1254,7 @@
 	.page-common a.button_add.button_add, .page-common a.button_add.button_edit, .page-common a.button_edit.button_add, .page-common a.button_edit.button_edit
 	{
 		border-color: transparent !important;
-	background-color: transparent !important;
+		background-color: transparent !important;
 	}
 	.page-common a.button_add.button_add:hover, .page-common a.button_add.button_edit:hover, .page-common a.button_edit.button_add:hover, .page-common a.button_edit.button_edit:hover
 	{
@@ -1266,26 +1266,41 @@
 	.page-common a.button_add.button_add.reading, .page-common a.button_add.button_add.watching, .page-common a.button_add.button_edit.reading, .page-common a.button_add.button_edit.watching, .page-common a.button_edit.button_add.reading, .page-common a.button_edit.button_add.watching, .page-common a.button_edit.button_edit.reading, .page-common a.button_edit.button_edit.watching
 	{
 		background-color: var(--green) !important;
+	}
+	.page-common a.button_add.button_add.reading span, .page-common a.button_add.button_add.watching span, .page-common a.button_add.button_edit.reading span, .page-common a.button_add.button_edit.watching span, .page-common a.button_edit.button_add.reading span, .page-common a.button_edit.button_add.watching span, .page-common a.button_edit.button_edit.reading span, .page-common a.button_edit.button_edit.watching span
+	{
 		color: #fff !important;
 	}
 	.page-common a.button_add.button_add.plantoread, .page-common a.button_add.button_add.plantowatch, .page-common a.button_add.button_edit.plantoread, .page-common a.button_add.button_edit.plantowatch, .page-common a.button_edit.button_add.plantoread, .page-common a.button_edit.button_add.plantowatch, .page-common a.button_edit.button_edit.plantoread, .page-common a.button_edit.button_edit.plantowatch
 	{
 		background-color: var(--gray) !important;
+	}
+	.page-common a.button_add.button_add.plantoread span, .page-common a.button_add.button_add.plantowatch span, .page-common a.button_add.button_edit.plantoread span, .page-common a.button_add.button_edit.plantowatch span, .page-common a.button_edit.button_add.plantoread span, .page-common a.button_edit.button_add.plantowatch span, .page-common a.button_edit.button_edit.plantoread span, .page-common a.button_edit.button_edit.plantowatch span
+	{
 		color: #fff !important;
 	}
 	.page-common a.button_add.button_add.completed, .page-common a.button_add.button_edit.completed, .page-common a.button_edit.button_add.completed, .page-common a.button_edit.button_edit.completed
 	{
 		background-color: var(--main-color) !important;
+	}
+	.page-common a.button_add.button_add.completed span, .page-common a.button_add.button_edit.completed span, .page-common a.button_edit.button_add.completed span, .page-common a.button_edit.button_edit.completed span
+	{
 		color: #fff !important;
 	}
 	.page-common a.button_add.button_add.dropped, .page-common a.button_add.button_edit.dropped, .page-common a.button_edit.button_add.dropped, .page-common a.button_edit.button_edit.dropped
 	{
 		background-color: var(--red) !important;
+	}
+	.page-common a.button_add.button_add.dropped span, .page-common a.button_add.button_edit.dropped span, .page-common a.button_edit.button_add.dropped span, .page-common a.button_edit.button_edit.dropped span
+	{
 		color: #fff !important;
 	}
 	.page-common a.button_add.button_add.on-hold, .page-common a.button_add.button_edit.on-hold, .page-common a.button_edit.button_add.on-hold, .page-common a.button_edit.button_edit.on-hold
 	{
 		background-color: var(--yellow) !important;
+	}
+	.page-common a.button_add.button_add.on-hold span, .page-common a.button_add.button_edit.on-hold span, .page-common a.button_edit.button_add.on-hold span, .page-common a.button_edit.button_edit.on-hold span
+	{
 		color: #fff !important;
 	}
 


### PR DESCRIPTION
Added new rule for text color inside span for **watching**, **plan no watch**,  **completed**, **dropped** and **on hold** records.
Reason for this is another [rule](https://github.com/RaitaroH/MyAnimeList-DeepDark/blob/3fc8604db4d704de79892c9abc0272966b589099/MyAnimeListDeepDark.user.css#L1678-L1681) where is redefined color for every span.

Before:
![Before](https://user-images.githubusercontent.com/40705899/180654651-1bdd7567-b6af-4f19-bb36-ec13650444e9.png)

After:
![After](https://user-images.githubusercontent.com/40705899/180654689-6ddc52be-7625-4b35-a9b8-19f06dcd49d1.png)
 