### PR TITLE
Omit opacity for interest-stacks-challenge image

### DIFF
--- a/MyAnimeListDeepDark.user.css
+++ b/MyAnimeListDeepDark.user.css
@@ -2,7 +2,7 @@
 @name MyAnimeList DeepDark
 @namespace gitlab.com/RaitaroH/MyAnimeList-DeepDark
 @homepageURL https://gitlab.com/RaitaroH/MyAnimeList-DeepDark
-@version 1.6.52
+@version 1.6.53
 @updateURL https://gitlab.com/RaitaroH/MyAnimeList-DeepDark/raw/master/MyAnimeListDeepDark.user.css
 @description  Satisfy thy craving for anime and organization. May the dark be kinder on thine eyes. (MyAnimeList Dark Theme)
 @author RaitaroH
@@ -930,7 +930,7 @@
 	}
 
 	/*Latest Updated Episode Videos*/
-	.page-common a, .page-common a:visited
+	.page-common a:not(.interest-stacks-challenge), .page-common a:visited
 	{
 		color: var(--main-color) !important;
 		opacity: .9;


### PR DESCRIPTION
For some reason, adding an opacity to _interest-stacks-challenge_ image (orange one on top) creates strange bar on right side of the image.
Since current opacity is 0.9, I think it's better to omit opacity than to have inconsistent view.
Before:
![Before](https://user-images.githubusercontent.com/40705899/181057514-69782147-6579-4ab2-b7c0-9b44c38ca37b.png)
After:
![After](https://user-images.githubusercontent.com/40705899/181057557-299a5773-77eb-4e84-bba0-108a0963dba5.png)
 