### PR TITLE
Search on news and stacks pages

### DIFF
--- a/MyAnimeListDeepDark.user.css
+++ b/MyAnimeListDeepDark.user.css
@@ -668,13 +668,15 @@
 
 
 	/*Search*/
-	.page-common #searchBar.searchBar #topSearchValue, .page-common #searchBar.searchBar #topSearchText, .page-common #searchBar.searchBar #topSearchButon.notActive, .page-common #searchBar.searchBar #topSearchButon, .news.featured .featured-search-side .featured-search-input-submit
+	.page-common #searchBar.searchBar #topSearchValue, .page-common #searchBar.searchBar #topSearchText, .page-common #searchBar.searchBar #topSearchButon.notActive, .page-common #searchBar.searchBar #topSearchButon, .news.featured .featured-search-side .featured-search-input-submit, .stacks .search-side form button
 	{
 		background: var(--second-background) !important;
 		color: var(--main-text) !important;
 		border-color: var(--hover-background) !important;
 	}
-	.page-common #searchBar.searchBar #topSearchText:hover, .page-common #searchBar.searchBar #topSearchText:active, .page-common #searchBar.searchBar #topSearchText:focus, .news.featured .featured-search-side .featured-search-input-text:active, .news.featured .featured-search-side .featured-search-input-text:hover, .news.featured .featured-search-side .featured-search-input-text:focus
+	.page-common #searchBar.searchBar #topSearchText:active, .page-common #searchBar.searchBar #topSearchText:focus, .page-common #searchBar.searchBar #topSearchText:hover,
+    .news.featured .featured-search-side .featured-search-input-text:active, .news.featured .featured-search-side .featured-search-input-text:focus, .news.featured .featured-search-side .featured-search-input-text:hover,
+    .stacks .search-side form input:active, .stacks .search-side form input:focus, .stacks .search-side form input:hover
 	{
 		border: 1px solid var(--main-color) !important;
 	}
@@ -1135,17 +1137,6 @@
 	}
 	.stacks .any_status .score .graph.completed {
 		background-color: var(--main-color) !important;
-	}
-	.stacks .search-side form input {
-		background-color: var(--second-background) !important;
-		border: 1px solid var(--hover-background) !important;
-		border-right: 0 solid var(--hover-background) !important;
-	}
-	.stacks .search-side form button {
-		background-color: var(--main-background) !important;
-		border: 1px solid var(--hover-background) !important;
-		border-left: 1px solid var(--hover-background) !important;
-		color: var(--main-text) !important;
 	}
 	.stacks .search-side .quick-search a {
 		background: var(--second-background) !important;
@@ -2857,7 +2848,7 @@
 	{
 		border-color: var(--hover-background) !important;
 	}
-    .news div .featured-side-block {
+    .news div .featured-side-block, .stacks div .search-side {
         width: 300px !important;
     }
 	body.news .menu-category .btn-category.selected

--- a/MyAnimeListDeepDark.user.css
+++ b/MyAnimeListDeepDark.user.css
@@ -668,7 +668,7 @@
 
 
 	/*Search*/
-	.page-common #searchBar.searchBar #topSearchValue, .page-common #searchBar.searchBar #topSearchText, .page-common #searchBar.searchBar #topSearchButon.notActive, .page-common #searchBar.searchBar #topSearchButon, .news.featured .featured-search-side .featured-search-input-text, .news.featured .featured-search-side .featured-search-input-submit
+	.page-common #searchBar.searchBar #topSearchValue, .page-common #searchBar.searchBar #topSearchText, .page-common #searchBar.searchBar #topSearchButon.notActive, .page-common #searchBar.searchBar #topSearchButon, .news.featured .featured-search-side .featured-search-input-submit
 	{
 		background: var(--second-background) !important;
 		color: var(--main-text) !important;
@@ -2857,6 +2857,9 @@
 	{
 		border-color: var(--hover-background) !important;
 	}
+    .news div .featured-side-block {
+        width: 300px !important;
+    }
 	body.news .menu-category .btn-category.selected
 	{
 		color: var(--main-text) !important;

--- a/MyAnimeListDeepDark.user.css
+++ b/MyAnimeListDeepDark.user.css
@@ -2,7 +2,7 @@
 @name MyAnimeList DeepDark
 @namespace gitlab.com/RaitaroH/MyAnimeList-DeepDark
 @homepageURL https://gitlab.com/RaitaroH/MyAnimeList-DeepDark
-@version 1.6.66
+@version 1.6.67
 @updateURL https://gitlab.com/RaitaroH/MyAnimeList-DeepDark/raw/master/MyAnimeListDeepDark.user.css
 @description  Satisfy thy craving for anime and organization. May the dark be kinder on thine eyes. (MyAnimeList Dark Theme)
 @author RaitaroH
@@ -2848,8 +2848,8 @@
 	{
 		border-color: var(--hover-background) !important;
 	}
-    .news div .featured-side-block, .stacks div .search-side {
-        width: 300px !important;
+	.news div .featured-side-block, .stacks div .search-side {
+    	width: 300px !important;
     }
 	body.news .menu-category .btn-category.selected
 	{


### PR DESCRIPTION
Fixed hover on search input on [news](https://myanimelist.net/news/tag) and [stacks](https://myanimelist.net/stacks/10973) pages.

News:

![Before_news](https://user-images.githubusercontent.com/40705899/183259000-641444cd-55ee-4e9f-8de4-03fa043cef54.png)

![After_news](https://user-images.githubusercontent.com/40705899/183258998-128f3490-5061-49d7-ac84-c3302588eaaf.png)


Stacks:

![Before_stacks](https://user-images.githubusercontent.com/40705899/183259006-2b596e04-eae6-4f8c-8a2b-b9f377f5700b.png)

![After_stacks](https://user-images.githubusercontent.com/40705899/183259003-344e7504-34c7-47d1-8d00-b144fa17c081.png)

