### PR TITLE
Episode count color is independent of progress-colors

### DIFF
--- a/MyAnimeListDeepDark.user.css
+++ b/MyAnimeListDeepDark.user.css
@@ -2,7 +2,7 @@
 @name MyAnimeList DeepDark
 @namespace gitlab.com/RaitaroH/MyAnimeList-DeepDark
 @homepageURL https://gitlab.com/RaitaroH/MyAnimeList-DeepDark
-@version 1.6.75
+@version 1.6.76
 @updateURL https://gitlab.com/RaitaroH/MyAnimeList-DeepDark/raw/master/MyAnimeListDeepDark.user.css
 @description  Satisfy thy craving for anime and organization. May the dark be kinder on thine eyes. (MyAnimeList Dark Theme)
 @author RaitaroH
@@ -1415,29 +1415,26 @@
 		{
 			background-color: var(--gray) !important;
 		}
-		.profile .statistics-updates .data .text.watching, .profile .statistics-updates .data .text.re-watching, .profile .statistics-updates .data .text.reading, .profile .statistics-updates .data .text.re-reading
-		{
-			color: var(--green) !important;
-		}
-		.profile .statistics-updates .data .text.completed
-		{
-			color: var(--main-color) !important;
-		}
-		.profile .statistics-updates .data .text.on_hold
-		{
-			color: var(--yellow) !important;
-		}
-		.profile .statistics-updates .data .text.dropped
-		{
-			color: var(--red) !important;
-		}
-		.profile .statistics-updates .data .text.plan_to_watch, .profile .statistics-updates .data .text.plan_to_read
-		{
-			color: var(--gray) !important;
-		}
 	}
-	.profile .statistics-updates .data .text.watching, .profile .statistics-updates .data .text.re-watching, .profile .statistics-updates .data .text.reading, .profile .statistics-updates .data .text.re-reading {
+	.profile .statistics-updates .data .text.watching, .profile .statistics-updates .data .text.re-watching, .profile .statistics-updates .data .text.reading, .profile .statistics-updates .data .text.re-reading
+	{
 		color: var(--green) !important;
+	}
+	.profile .statistics-updates .data .text.completed
+	{
+		color: var(--main-color) !important;
+	}
+	.profile .statistics-updates .data .text.on_hold
+	{
+		color: var(--yellow) !important;
+	}
+	.profile .statistics-updates .data .text.dropped
+	{
+		color: var(--red) !important;
+	}
+	.profile .statistics-updates .data .text.plan_to_watch, .profile .statistics-updates .data .text.plan_to_read
+	{
+		color: var(--gray) !important;
 	}
 	.profile .user-statistics .stats-graph
 	{


### PR DESCRIPTION
@ShadyDeth
Is this a valid change? Should I introduce variables for MAL's real color on white theme and use those variables when _progress-colors_ is false?
Currently episode counter has color of _dimmer-text_, but with changes it will take our variations of red, yellow,... colors.

![Before](https://user-images.githubusercontent.com/40705899/186956583-20169926-d3c3-44a3-962b-e410ad7521fe.png)
![After](https://user-images.githubusercontent.com/40705899/186956584-b18d0f3d-a814-4aa5-9ca2-e42b06929cd6.png)

