### PR TITLE
Colors for list of items

### DIFF
--- a/MyAnimeListDeepDark.user.css
+++ b/MyAnimeListDeepDark.user.css
@@ -2,7 +2,7 @@
 @name MyAnimeList DeepDark
 @namespace gitlab.com/RaitaroH/MyAnimeList-DeepDark
 @homepageURL https://github.com/RaitaroH/MyAnimeList-DeepDark
-@version 1.7.09
+@version 1.7.10
 @updateURL https://github.com/RaitaroH/MyAnimeList-DeepDark/raw/master/MyAnimeListDeepDark.user.css
 @description  Satisfy thy craving for anime and organization. May the dark be kinder on thine eyes. (MyAnimeList Dark Theme)
 @author RaitaroH

--- a/MyAnimeListDeepDark.user.css
+++ b/MyAnimeListDeepDark.user.css
@@ -3914,6 +3914,18 @@
 		color: var(--main-color) !important;
 	}
 
+	/*Staff*/
+	.staff .staff_wrap div.staff:nth-of-type(2n+1)
+	{
+		background-color: var(--main-background) !important;
+		color: var(--dimmer-text) !important;
+	}
+	.staff .staff_wrap div.staff:nth-of-type(2n)
+	{
+		background-color: var(--hover-background) !important;
+		color: var(--dimmer-text) !important;
+	}
+
 
 /*Support for addon scripts*/
 

--- a/MyAnimeListDeepDark.user.css
+++ b/MyAnimeListDeepDark.user.css
@@ -3054,10 +3054,15 @@
 		filter: grayscale(100%);
 		opacity: 1 !important;
 	}
-	.setting-row.locate-right, .setting-row.show-hidden
+	.setting-row.locate-right
 	{
+		background-color: var(--hover-background) !important;
 		color: var(--main-text) !important;
+	}
+	.setting-row.show-hidden td, .setting-row.show-hidden td span
+	{
 		background-color: var(--main-background) !important;
+		color: var(--select-background) !important;
 	}
 	.settings-cunstom-forum-title input:disabled, .sns-setting .table tr:nth-of-type(2n+1) td
 	{


### PR DESCRIPTION
- Fixed colors for list of staff members on [staff](https://myanimelist.net/staff) page:

![Before_staff](https://user-images.githubusercontent.com/40705899/204342273-461df609-1607-4f46-a969-3eafc15b50bd.png)
![After_staff](https://user-images.githubusercontent.com/40705899/204342264-88d1a85b-cb2c-4dc9-a869-31c56af314f5.png)

- Fixed colors for list of [panel settings](https://myanimelist.net/editprofile.php?go=panelsettings)
  - P.S. Change was made based on MAL's design where unused settings has different text color

![Before_panel](https://user-images.githubusercontent.com/40705899/204342479-a3769ecd-cb71-4efb-914a-0becf24d0d90.png)
![After_panel](https://user-images.githubusercontent.com/40705899/204342489-558c31a2-5948-4b47-b2e5-c8993d3ef918.png)

