### PR TITLE
Minor visual improvements

### DIFF
--- a/MyAnimeListDeepDark.user.css
+++ b/MyAnimeListDeepDark.user.css
@@ -2144,9 +2144,28 @@
 		border-color: var(--hover-background) !important;
 		background-color: var(--hover-background) !important;
 	}
-	a.icon-team-title.founder, a.icon-team-title.site_administrator, a.icon-team-title.lead_administrator, a.icon-team-title.community_administrator, a.icon-team-title.database_administrator, a.icon-team-title.anime_db_moderator, a.icon-team-title.manga_db_moderator, a.icon-team-title.forum_moderator, a.icon-team-title.news_moderator, a.icon-team-title.review_recommendation_moderator, a.icon-team-title.irc_moderator, a.icon-team-title.social_media_moderator, a.icon-team-title.retired_moderator, a.icon-team-title.event_bot, a.icon-team-title.community_moderator, a.icon-team-title.founder:visited, a.icon-team-title.site_administrator:visited, a.icon-team-title.lead_administrator:visited, a.icon-team-title.community_administrator:visited, a.icon-team-title.database_administrator:visited, a.icon-team-title.anime_db_moderator:visited, a.icon-team-title.manga_db_moderator:visited, a.icon-team-title.forum_moderator:visited, a.icon-team-title.news_moderator:visited, a.icon-team-title.review_recommendation_moderator:visited, a.icon-team-title.irc_moderator:visited, a.icon-team-title.social_media_moderator:visited, a.icon-team-title.retired_moderator:visited, a.icon-team-title.event_bot:visited, a.icon-team-title.community_moderator:visited
+	a.icon-team-title.founder, a.icon-team-title.founder:visited,
+	a.icon-team-title.site_administrator, a.icon-team-title.site_administrator:visited,
+	a.icon-team-title.lead_administrator, a.icon-team-title.lead_administrator:visited,
+	a.icon-team-title.community_administrator, a.icon-team-title.community_administrator:visited,
+	a.icon-team-title.database_administrator, a.icon-team-title.database_administrator:visited,
+	a.icon-team-title.forum_moderator, a.icon-team-title.forum_moderator:visited, 
+	a.icon-team-title.news_moderator, a.icon-team-title.news_moderator:visited,
+	a.icon-team-title.review_recommendation_moderator, a.icon-team-title.review_recommendation_moderator:visited,
+	a.icon-team-title.irc_moderator, a.icon-team-title.irc_moderator:visited,
+	a.icon-team-title.social_media_moderator, a.icon-team-title.social_media_moderator:visited,
+	a.icon-team-title.retired_moderator, a.icon-team-title.retired_moderator:visited,
+	a.icon-team-title.event_bot, a.icon-team-title.event_bot:visited,
+	a.icon-team-title.community_moderator, a.icon-team-title.community_moderator:visited,
+	a.icon-team-title.rewrite_moderator, a.icon-team-title.rewrite_moderator:hover
 	{
 		color: var(--main-text) !important;
+		transition: none !important;
+	}
+	a.icon-team-title.anime_db_moderator, a.icon-team-title.anime_db_moderator:visited,
+	a.icon-team-title.manga_db_moderator, a.icon-team-title.manga_db_moderator:visited
+	{
+		color: var(--main-background) !important;
 		transition: none !important;
 	}
 	.page-forum .sig

--- a/MyAnimeListDeepDark.user.css
+++ b/MyAnimeListDeepDark.user.css
@@ -1055,7 +1055,7 @@
 		color: var(--main-color) !important;
 		opacity: 1;
 	}
-	.page-common .notice_open_public, .page-common .info, .page-common .broadcast-item.notavailable .caption:after, .stacks .caution, .page-common [style="color: red;"], .page-common [style="color: #b25959;"]
+	.page-common .notice_open_public, .page-common .info, .page-common .broadcast-item.notavailable .caption:after, .stacks .caution, .page-common .badresult-text, .page-common [style="color: red;"], .page-common [style="color: #b25959;"]
 	{
 		color: var(--red) !important;
 	}

--- a/MyAnimeListDeepDark.user.css
+++ b/MyAnimeListDeepDark.user.css
@@ -2,7 +2,7 @@
 @name MyAnimeList DeepDark
 @namespace gitlab.com/RaitaroH/MyAnimeList-DeepDark
 @homepageURL https://github.com/RaitaroH/MyAnimeList-DeepDark
-@version 1.7.10
+@version 1.7.11
 @updateURL https://github.com/RaitaroH/MyAnimeList-DeepDark/raw/master/MyAnimeListDeepDark.user.css
 @description  Satisfy thy craving for anime and organization. May the dark be kinder on thine eyes. (MyAnimeList Dark Theme)
 @author RaitaroH
@@ -1126,33 +1126,6 @@
 	.page-common .lightLink:hover
 	{
 		color: var(--main-color) !important;
-	}
-
-
-	/*Featured Articles*/
-	.news-list .comment-list .information .info, .news-list .news-unit .information .info, .news-list .comment-list .information .pv, .news-list .news-unit .information .pv
-	{
-		color: var(--dimmer-text) !important;
-	}
-	.news-list .comment-list .information .tags .tag.tag-color-feature-advertorial:hover, .news-list .news-unit .information .tags .tag.tag-color-feature-advertorial:hover, .news-list .comment-list .information .tags .tag.tag-color-feature-spoiler:hover, .news-list .news-unit .information .tags .tag.tag-color-feature-spoiler:hover
-	{
-		background-color: transparent !important;
-	}
-	.news-list .comment-list .information .tags .tag.tag-color-feature-advertorial, .news-list .news-unit .information .tags .tag.tag-color-feature-advertorial, .news-list .comment-list .information .tags .tag.tag-color-feature-advertorial:hover, .news-list .news-unit .information .tags .tag.tag-color-feature-advertorial:hover
-	{
-		color: var(--main-text) !important;
-		border-color: var(--main-color) !important;
-		background-color: var(--main-color) !important;
-	}
-	.news-list .comment-list .information .tags .tag.tag-color-feature-spoiler, .news-list .news-unit .information .tags .tag.tag-color-feature-spoiler, .news-list .comment-list .information .tags .tag.tag-color-feature-spoiler:hover, .news-list .news-unit .information .tags .tag.tag-color-feature-spoiler:hover
-	{
-		color: #fff !important;
-		border-color: var(--red) !important;
-		background-color: var(--red) !important;
-	}
-	.news-list .comment-list .information .pv, .news-list .news-unit .information .pv, .news-list .comment-list .information .tags, .news-list .news-unit .information .tags
-	{
-		border-color: var(--hover-background) !important;
 	}
 
 
@@ -3229,6 +3202,37 @@
 	{
 		border-color: var(--hover-background) !important;
 	}
+	.news-list .comment-list .information .info, .news-list .news-unit .information .info, .news-list .comment-list .information .pv, .news-list .news-unit .information .pv
+	{
+		color: var(--dimmer-text) !important;
+	}
+	.news-list .comment-list .information .tags .tag.tag-color-feature-advertorial:hover, .news-list .news-unit .information .tags .tag.tag-color-feature-advertorial:hover,
+	.news-list .comment-list .information .tags .tag.tag-color-feature-spoiler:hover, .news-list .news-unit .information .tags .tag.tag-color-feature-spoiler:hover
+	{
+		background-color: transparent !important;
+	}
+	.news-list .comment-list .information .tags .tag.tag-color-feature-advertorial, .news-list .comment-list .information .tags .tag.tag-color-feature-advertorial:hover,
+	.news-list .news-unit .information .tags .tag.tag-color-feature-advertorial, .news-list .news-unit .information .tags .tag.tag-color-feature-advertorial:hover,
+	.featured-pickup .featured-pickup-unit .information .tags .tag.tag-color-feature-advertorial
+	{
+		color: var(--main-text) !important;
+		border-color: var(--main-color) !important;
+		background-color: var(--main-color) !important;
+	}
+	.news-list .comment-list .information .tags .tag.tag-color-feature-spoiler, .news-list .comment-list .information .tags .tag.tag-color-feature-spoiler:hover,
+	.news-list .news-unit .information .tags .tag.tag-color-feature-spoiler, .news-list .news-unit .information .tags .tag.tag-color-feature-spoiler:hover,
+	.news .news-container .tags-inner-attributes .tag.tag-color-feature-spoiler,
+	.featured-pickup .featured-pickup-unit .information .tags .tag.tag-color-feature-spoiler
+	{
+		color: #fff !important;
+		border-color: var(--red) !important;
+		background-color: var(--red) !important;
+	}
+	.news-list .comment-list .information .pv, .news-list .news-unit .information .pv, .news-list .comment-list .information .tags, .news-list .news-unit .information .tags
+	{
+		border-color: var(--hover-background) !important;
+	}
+
 	/*Tags*/
 	body.news .menu-category .btn-edit-tags
 	{
@@ -3236,19 +3240,23 @@
 		border-color: var(--main-color) !important;
 		color: var(--main-text) !important;
 	}
-	.news-list .comment-list .information .tags .tag.tag-color1, .news-list .news-unit .information .tags .tag.tag-color1, body.news .tag-side-block .tag-cloud .tag.tag-color1, .featured-pickup .featured-pickup-unit .information .tags .tag.tag-color-feature-spoiler, body.news .news-side-block .news-list .text-color-spoiler, body.news .news-side-block .featured-list .text-color-spoiler, body.news .featured-side-block .news-list .text-color-spoiler, body.news .featured-side-block .featured-list .text-color-spoiler
+	.news-list .comment-list .information .tags .tag.tag-color1, .news-list .news-unit .information .tags .tag.tag-color1, body.news .tag-side-block .tag-cloud .tag.tag-color1,
+	body.news .news-side-block .news-list .text-color-spoiler, body.news .news-side-block .featured-list .text-color-spoiler,
+	body.news .featured-side-block .news-list .text-color-spoiler, body.news .featured-side-block .featured-list .text-color-spoiler
 	{
 		background-color: var(--red) !important;
 		border-color: var(--red) !important;
 		color: #fff !important;
 	}
-	.news-list .comment-list .information .tags .tag.tag-color4, .news-list .news-unit .information .tags .tag.tag-color4, body.news .tag-side-block .tag-cloud .tag.tag-color4, .featured-pickup .featured-pickup-unit .information .tags .tag.tag-color-feature-advertorial
+	.news-list .comment-list .information .tags .tag.tag-color4, .news-list .news-unit .information .tags .tag.tag-color4, body.news .tag-side-block .tag-cloud .tag.tag-color4
 	{
 		background-color: var(--main-color) !important;
 		border-color: var(--main-color) !important;
 		color: var(--main-text) !important;
 	}
-	.news-list .comment-list .information .tags .tag.tag-color6, .news-list .news-unit .information .tags .tag.tag-color6, body.news .tag-side-block .tag-cloud .tag.tag-color6, body.news .tag-side-block .tag-cloud .tag, .news-list .comment-list .information .tags .tag, .news-list .news-unit .information .tags .tag
+	.news-list .comment-list .information .tags .tag.tag-color6, .news-list .news-unit .information .tags .tag.tag-color6, body.news .tag-side-block .tag-cloud .tag.tag-color6,
+	.news .tag-side-block .tag-cloud .tag,
+	.news-list .comment-list .information .tags .tag, .news-list .news-unit .information .tags .tag
 	{
 		background-color: var(--gray) !important;
 		border-color: var(--gray) !important;
@@ -3296,9 +3304,13 @@
 	{
 		color: var(--purple) !important;
 	}
-	.news .news-container .tags .tag.tag-color6
+	.news .news-container .tags .tag, .news .news-container .tags .tag.tag-color6
 	{
 		color: var(--gray) !important;
+	}
+	.news .news-container .tags
+	{
+		padding-left: 8px !important;
 	}
 	.news .news-content-block.news-tags .menu-category-tags li
 	{


### PR DESCRIPTION
- Fixed red color .badresult.-text div:
  - P.S. Before this change second line had MAL's red color

![After_red-text](https://user-images.githubusercontent.com/40705899/204623856-b8217709-1086-4966-94b3-b4ed10664df0.png)

- Fixed colors for titles ([anime DB moderator](https://myanimelist.net/profile/Aquarius), [manga DB moderator](https://myanimelist.net/profile/batsling1234) and [rewrite moderator](https://myanimelist.net/profile/neil)):

![Before_rewrite](https://user-images.githubusercontent.com/40705899/204624430-b000b789-da99-448c-b76a-dad33c6f597e.png)
![After_rewrite](https://user-images.githubusercontent.com/40705899/204624435-45d1c5b8-4092-4461-9026-8e3429eb4268.png)

![Before_moderator](https://user-images.githubusercontent.com/40705899/204624465-afb4f90e-2405-4a0f-a449-e38d703c0e0d.png)
![After_moderator](https://user-images.githubusercontent.com/40705899/204624474-e0bd0291-fbd6-4263-b66a-4a1a1ddb6b74.png)

- Fixed tag colors on [featured articles](https://myanimelist.net/featured/1361/Religion_and_Symbolism_in_Neon_Genesis_Evangelion) page:
  - Same as it is on [news](https://myanimelist.net/news/67390014) page

![Before_tags](https://user-images.githubusercontent.com/40705899/204625214-cae67894-1c79-4560-8f10-e82936778a44.png)
![After_tags](https://user-images.githubusercontent.com/40705899/204625240-3acde015-bcb3-4da2-949d-a7fcdb2cd794.png)

- Tag selectors grouped in one place
  - P.S. Styling for tags remained same for [featured](https://myanimelist.net/featured/tag/sci-fi), [news](https://myanimelist.net/news/58353510) and [news tag](https://myanimelist.net/news/tag) pages
